### PR TITLE
Add missing property names to test stubs

### DIFF
--- a/lib/Horde/Test/Stub/Registry.php
+++ b/lib/Horde/Test/Stub/Registry.php
@@ -50,7 +50,7 @@ class Horde_Test_Stub_Registry
      *
      * @var array
      */
-    protected $_configObjects = array();
+    protected $configObjects = [];
 
     /**
      * Constructor.

--- a/lib/Horde/Test/Stub/Registry/Loadconfig.php
+++ b/lib/Horde/Test/Stub/Registry/Loadconfig.php
@@ -23,8 +23,9 @@
 class Horde_Test_Stub_Registry_Loadconfig
 {
     public $app;
-    public $conf_files;
+    public $conf_file;
     public $vars;
+    public $config = [];
 
     public function __construct($app, $conf_file, $vars)
     {


### PR DESCRIPTION
This is to fix test deprecations reported by phpunit.

This is a short term fix. Tests would need to be adjusted/expanded, anyway.